### PR TITLE
avoid nil error in actors:all smart devices request

### DIFF
--- a/lib/fritzbox/smarthome/actor.rb
+++ b/lib/fritzbox/smarthome/actor.rb
@@ -20,7 +20,7 @@ module Fritzbox
           response = get(command: 'getdevicelistinfos')
           xml = nori.parse(response.body)
 
-          Array.wrap(types.map { |type| xml.dig('devicelist', type) }.flatten).map do |data|
+          Array.wrap(types.map { |type| xml.dig('devicelist', type) }.flatten).compact.map do |data|
             new_from_api(data)
           end
         end

--- a/spec/fritzbox/smarthome/actor_spec.rb
+++ b/spec/fritzbox/smarthome/actor_spec.rb
@@ -10,12 +10,40 @@ RSpec.describe Fritzbox::Smarthome::Actor do
   end
 
   describe '.all' do
-    before do
+    it 'returns a list of actors' do
       stub_request(:get, 'https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=getdevicelistinfos').
         to_return(body: File.read(File.expand_path('../../../support/fixtures/getdevicelistinfos.xml', __FILE__)))
+
+      actors = described_class.all
+      expect(actors.size).to eq 2
+
+      actor = actors.shift
+      expect(actor.type).to                   eq :device
+      expect(actor.id).to                     eq '18'
+      expect(actor.ain).to                    eq '12345 678901'
+      expect(actor.name).to                   eq 'Heizung Wohnzimmer'
+      expect(actor.hkr_temp_is).to            eq 20.5
+      expect(actor.hkr_temp_set).to           eq 16.0
+      expect(actor.hkr_next_change_period).to eq Time.new(2018, 4, 10, 6, 0, 0, '+02:00')
+      expect(actor.hkr_next_change_temp).to   eq 23.0
+      expect(actor.group_members).to          be nil
+
+      actor = actors.shift
+      expect(actor.type).to                   eq :device
+      expect(actor.id).to                     eq '16'
+      expect(actor.ain).to                    eq '12345 678902'
+      expect(actor.name).to                   eq 'Heizung Küche'
+      expect(actor.hkr_temp_is).to            eq 20.5
+      expect(actor.hkr_temp_set).to           eq 16.0
+      expect(actor.hkr_next_change_period).to eq Time.new(2018, 4, 10, 6, 0, 0, '+02:00')
+      expect(actor.hkr_next_change_temp).to   eq 23.0
+      expect(actor.group_members).to          be nil
     end
 
-    it 'returns a list of actors' do
+    it 'returns a list of actors and group' do
+      stub_request(:get, 'https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=getdevicelistinfos').
+        to_return(body: File.read(File.expand_path('../../../support/fixtures/getdeviceandgrouplistinfos.xml', __FILE__)))
+
       actors = described_class.all
       expect(actors.size).to eq 3
 

--- a/spec/support/fixtures/getdeviceandgrouplistinfos.xml
+++ b/spec/support/fixtures/getdeviceandgrouplistinfos.xml
@@ -1,5 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <devicelist version="1">
+  <group identifier="65:0A:0C-900" id="900" functionbitmask="4160" fwversion="1.0" manufacturer="AVM" productname="">
+    <present>1</present>
+    <name>Heizungen</name>
+    <hkr>
+      <tist>42</tist>
+      <tsoll>32</tsoll>
+      <absenk>32</absenk>
+      <komfort>46</komfort>
+      <lock>0</lock>
+      <devicelock>0</devicelock>
+      <errorcode>0</errorcode>
+      <batterylow>0</batterylow>
+      <nextchange>
+        <endperiod>1523332800</endperiod>
+        <tchange>46</tchange>
+      </nextchange>
+    </hkr>
+    <groupinfo>
+      <masterdeviceid>0</masterdeviceid>
+      <members>18,16</members>
+    </groupinfo>
+  </group>
   <device identifier="12345 678901" id="18" functionbitmask="320" fwversion="03.54" manufacturer="AVM" productname="Comet DECT">
     <present>1</present>
     <name>Heizung Wohnzimmer</name>


### PR DESCRIPTION
In case of different smart devices like switches or smoke detectors Actor::all returns nil objects, which lead to errors in new_from_api function.