### PR TITLE
Use generic Actor class for unrecognised device

### DIFF
--- a/lib/fritzbox/smarthome/actor.rb
+++ b/lib/fritzbox/smarthome/actor.rb
@@ -17,7 +17,7 @@ module Fritzbox
           response = get(command: 'getdevicelistinfos')
           xml = nori.parse(response.body)
           Array.wrap(types.map { |type| xml.dig('devicelist', type) }.flatten).compact.map do |data|
-            klass = Actor.descendants.find { |k| k.match?(data) } || self
+            klass = Actor.descendants.find { |k| k.match?(data) } || Actor
             self.in?([klass, Actor]) ? klass.new_from_api(data) : nil
           end.compact
         end

--- a/lib/fritzbox/smarthome/actor.rb
+++ b/lib/fritzbox/smarthome/actor.rb
@@ -17,7 +17,7 @@ module Fritzbox
           response = get(command: 'getdevicelistinfos')
           xml = nori.parse(response.body)
           Array.wrap(types.map { |type| xml.dig('devicelist', type) }.flatten).compact.map do |data|
-            klass = Actor.descendants.find { |k| k.match?(data) }
+            klass = Actor.descendants.find { |k| k.match?(data) } || self
             self.in?([klass, Actor]) ? klass.new_from_api(data) : nil
           end.compact
         end
@@ -28,7 +28,7 @@ module Fritzbox
             type:          data.dig('groupinfo').present? ? :group : :device,
             ain:           data.dig('@identifier').to_s,
             present:       data.dig('present') == '1',
-            name:          data.dig('name').to_s,
+            name:          (data.dig('name') || data.dig('@productname')).to_s,
             manufacturer:  data.dig('manufacturer').to_s,
             group_members: data.dig('groupinfo', 'members').to_s.split(',').presence
           )

--- a/spec/fritzbox/smarthome/actor_spec.rb
+++ b/spec/fritzbox/smarthome/actor_spec.rb
@@ -62,5 +62,22 @@ RSpec.describe Fritzbox::Smarthome::Actor do
       expect(actor.manufacturer).to           eq 'AVM'
       expect(actor.group_members).to          be nil
     end
+
+    it 'does not fail when it encounters an unknown actor type' do
+      stub_request(:get, 'https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=getdevicelistinfos').
+        to_return(body: File.read(File.expand_path('../../../support/fixtures/getdevicelistinfos_with_unrecognised_device.xml', __FILE__)))
+
+      actors = described_class.all
+      expect(actors.size).to eq 1
+
+      actor = actors.shift
+      expect(actor.class).to                  eq Fritzbox::Smarthome::Actor
+      expect(actor.type).to                   eq :device
+      expect(actor.id).to                     eq "4711"
+      expect(actor.ain).to                    eq "12345 54321"
+      expect(actor.name).to                   eq "Sub-Etha Radio Transmitter"
+      expect(actor.manufacturer).to           eq ""
+      expect(actor.group_members).to          be nil
+    end
   end
 end

--- a/spec/fritzbox/smarthome/actor_spec.rb
+++ b/spec/fritzbox/smarthome/actor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Fritzbox::Smarthome::Actor do
         to_return(body: File.read(File.expand_path('../../../support/fixtures/getdevicelistinfos.xml', __FILE__)))
 
       actors = described_class.all
-      expect(actors.size).to eq 5
+      expect(actors.size).to eq 6
 
       actor = actors.shift
       expect(actor.class).to                  eq Fritzbox::Smarthome::Heater
@@ -61,15 +61,8 @@ RSpec.describe Fritzbox::Smarthome::Actor do
       expect(actor.name).to                   eq 'FRITZ!DECT 200 Steckdose'
       expect(actor.manufacturer).to           eq 'AVM'
       expect(actor.group_members).to          be nil
-    end
 
-    it 'does not fail when it encounters an unknown actor type' do
-      stub_request(:get, 'https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=getdevicelistinfos').
-        to_return(body: File.read(File.expand_path('../../../support/fixtures/getdevicelistinfos_with_unrecognised_device.xml', __FILE__)))
-
-      actors = described_class.all
-      expect(actors.size).to eq 1
-
+      # An unrecognised device that couldn't be linked to a specific Actor subclass:
       actor = actors.shift
       expect(actor.class).to                  eq Fritzbox::Smarthome::Actor
       expect(actor.type).to                   eq :device

--- a/spec/support/fixtures/getdevicelistinfos.xml
+++ b/spec/support/fixtures/getdevicelistinfos.xml
@@ -89,4 +89,5 @@
       <offset>-5</offset>
     </temperature>
   </device>
+  <device identifier="12345 54321" id="4711" functionbitmask="007" fwversion="0815" productname="Sub-Etha Radio Transmitter"></device>
 </devicelist>

--- a/spec/support/fixtures/getdevicelistinfos_with_unrecognised_device.xml
+++ b/spec/support/fixtures/getdevicelistinfos_with_unrecognised_device.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<devicelist version="1">
-  <device identifier="12345 54321" id="4711" functionbitmask="007" fwversion="0815" productname="Sub-Etha Radio Transmitter">
-  </device>
-</devicelist>

--- a/spec/support/fixtures/getdevicelistinfos_with_unrecognised_device.xml
+++ b/spec/support/fixtures/getdevicelistinfos_with_unrecognised_device.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<devicelist version="1">
+  <device identifier="12345 54321" id="4711" functionbitmask="007" fwversion="0815" productname="Sub-Etha Radio Transmitter">
+  </device>
+</devicelist>


### PR DESCRIPTION
Prevents calling `new_from_api` on `nil` in Actor.all when the Actor subclasses's `match?` predicates don't find a suitable class.

Specifically, I have a Fritz!DECT 500 (the lightbulb¹) and it swam belly up when getting all actors. I deliberately didn't add a proper XML for the 500 as I wanted this to work with all unrecognised devices.

I sneaked in a change to attempt to assign an actor instance's name from the product name XML attribute as well, just so that I could see what devices are being returned. Happy to change it back.

```
NoMethodError: undefined method `new_from_api' for nil
```

¹) I might add a real actor subclass for it in the near future