### PR TITLE
Add support for Fritz!DECT lightbulbs

### DIFF
--- a/lib/fritzbox/smarthome.rb
+++ b/lib/fritzbox/smarthome.rb
@@ -4,6 +4,7 @@ require 'httparty'
 require 'nori'
 
 require 'fritzbox/smarthome/version'
+require 'fritzbox/smarthome/null_logger'
 require 'fritzbox/smarthome/resource'
 require 'fritzbox/smarthome/actor'
 require 'fritzbox/smarthome/heater'
@@ -28,7 +29,7 @@ module Fritzbox
       defaults.username   = 'smarthome'
       defaults.password   = 'verysmart'
       defaults.verify_ssl = true
-      defaults.logger     = nil
+      defaults.logger     = NullLogger.new
     end
 
     class << self

--- a/lib/fritzbox/smarthome.rb
+++ b/lib/fritzbox/smarthome.rb
@@ -10,6 +10,7 @@ require 'fritzbox/smarthome/actor'
 require 'fritzbox/smarthome/heater'
 require 'fritzbox/smarthome/switch'
 require 'fritzbox/smarthome/smoke_detector'
+require 'fritzbox/smarthome/lightbulb'
 
 module Fritzbox
   module Smarthome

--- a/lib/fritzbox/smarthome/actor.rb
+++ b/lib/fritzbox/smarthome/actor.rb
@@ -29,7 +29,7 @@ module Fritzbox
             ain:           data.dig('@identifier').to_s,
             present:       data.dig('present') == '1',
             name:          (data.dig('name') || data.dig('@productname')).to_s,
-            manufacturer:  data.dig('manufacturer').to_s,
+            manufacturer:  (data.dig('manufacturer') || data.dig('@manufacturer')).to_s,
             group_members: data.dig('groupinfo', 'members').to_s.split(',').presence
           )
         end

--- a/lib/fritzbox/smarthome/lightbulb.rb
+++ b/lib/fritzbox/smarthome/lightbulb.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Fritzbox
+  module Smarthome
+    class Lightbulb < Actor
+
+      attr_accessor \
+        :simpleonoff_state
+
+      class << self
+        def match?(data)
+          data.fetch('@productname', '') =~ /FRITZ!DECT 5\d{2}/i
+        end
+
+        def new_from_api(data)
+          instance = super
+          instance.assign_attributes(
+            simpleonoff_state:   data.dig('simpleonoff', 'state').to_i,
+          )
+          instance
+        end
+      end
+
+      def active?
+        simpleonoff_state == 1
+      end
+
+      def toggle!
+        value = active? ? 0 : 1
+        response = self.class.get(command: 'setsimpleonoff', ain: ain, onoff: value)
+
+        response.ok? && @simpleonoff_state = value
+      end
+    end
+  end
+end

--- a/lib/fritzbox/smarthome/null_logger.rb
+++ b/lib/fritzbox/smarthome/null_logger.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Fritzbox
+  module Smarthome
+    class NullLogger < Logger
+      def initialize(*_args)
+        super(File::NULL)
+      end
+    end
+  end
+end

--- a/lib/fritzbox/smarthome/resource.rb
+++ b/lib/fritzbox/smarthome/resource.rb
@@ -2,10 +2,17 @@ module Fritzbox
   module Smarthome
     class Resource
       class << self
-        def get(command:, ain: nil, param: nil)
+        # @param params [Hash] key/value pairs that will be appended to the switchcmd query string
+        def get(command:, ain: nil, param: nil, **params)
           url = "#{config.endpoint}/webservices/homeautoswitch.lua?switchcmd=#{command}&sid=#{authenticate}"
           url = "#{url}&ain=#{ain}"     if ain.present?
           url = "#{url}&param=#{param}" if param.present?
+
+          params.each_with_object(url) do |(key, value)|
+            url = "#{url}&#{key}=#{value}"
+          end
+
+          config.logger.debug(url)
 
           HTTParty.get(url, **httparty_options)
         end

--- a/spec/fritzbox/smarthome/actor_spec.rb
+++ b/spec/fritzbox/smarthome/actor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Fritzbox::Smarthome::Actor do
         to_return(body: File.read(File.expand_path('../../../support/fixtures/getdevicelistinfos.xml', __FILE__)))
 
       actors = described_class.all
-      expect(actors.size).to eq 6
+      expect(actors.size).to eq 7
 
       actor = actors.shift
       expect(actor.class).to                  eq Fritzbox::Smarthome::Heater
@@ -71,6 +71,28 @@ RSpec.describe Fritzbox::Smarthome::Actor do
       expect(actor.name).to                   eq "Sub-Etha Radio Transmitter"
       expect(actor.manufacturer).to           eq ""
       expect(actor.group_members).to          be nil
+    end
+  end
+
+  describe '.new_from_api' do
+    subject(:actor) { described_class.new_from_api(data) }
+
+    let(:data) { Hash.new }
+
+    context 'when setting the manufacturer' do
+      let!(:data) { { '@manufacturer' => 'Orang-Utan Klaus' } }
+
+      it 'sets #manufacturer based on an XML attribute' do
+        expect(actor.manufacturer).to eql 'Orang-Utan Klaus'
+      end
+
+      context "when an XML node is present" do
+        let!(:data) { { '@manufacturer' => 'Orang-Utan Klaus', 'manufacturer' => 'Telefonmann' } }
+
+        it "takes precedence over a @manufacturer XML attribute" do
+          expect(actor.manufacturer).to eql 'Telefonmann'
+        end
+      end
     end
   end
 end

--- a/spec/fritzbox/smarthome/actor_spec.rb
+++ b/spec/fritzbox/smarthome/actor_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe Fritzbox::Smarthome::Actor do
       expect(actor.name).to                   eq "Sub-Etha Radio Transmitter"
       expect(actor.manufacturer).to           eq ""
       expect(actor.group_members).to          be nil
+
+      actor = actors.shift
+      expect(actor.class).to                  eq Fritzbox::Smarthome::Lightbulb
+      expect(actor.type).to                   eq :device
+      expect(actor.id).to                     eq "406"
+      expect(actor.ain).to                    eq "11111 2233445"
+      expect(actor.name).to                   eq "Flurlampe"
+      expect(actor.manufacturer).to           eq "AVM"
+      expect(actor.group_members).to          be nil
     end
   end
 

--- a/spec/fritzbox/smarthome/lightbulb_spec.rb
+++ b/spec/fritzbox/smarthome/lightbulb_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe Fritzbox::Smarthome::Lightbulb do
+  subject(:lightbulb) do
+    described_class.new_from_api({ 'simpleonoff' => { 'state' => state } })
+  end
+
+  before do
+    stub_request(:get, 'https://fritz.box/login_sid.lua').
+      to_return(body: '<SessionInfo><Challenge>1234567z</Challenge></SessionInfo>')
+
+    stub_request(:get, 'https://fritz.box/login_sid.lua?response=1234567z-8d08321fe007cd28e2eae9f9051628db&username=smarthome').
+      to_return(body: '<SessionInfo><SID>ff88e4d39354992f</SID></SessionInfo>')
+  end
+
+  describe '.all' do
+    it 'returns a list of lightbulbs' do
+      stub_request(:get, 'https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=getdevicelistinfos').
+        to_return(body: File.read(File.expand_path('../../../support/fixtures/getdevicelistinfos.xml', __FILE__)))
+
+      lightbulbs = described_class.all
+      expect(lightbulbs.size).to eq 1
+
+      lightbulb = lightbulbs.shift
+      expect(lightbulb.type).to                   eq :device
+      expect(lightbulb.id).to                     eq '406'
+      expect(lightbulb.ain).to                    eq '11111 2233445'
+      expect(lightbulb.name).to                   eq 'Flurlampe'
+      expect(lightbulb.manufacturer).to           eq 'AVM'
+    end
+  end
+
+  describe '#active?' do
+    subject { lightbulb.active? }
+
+    context 'when simpleonoff_state is "0"' do
+      let(:state) { '0' }
+      it { is_expected.to be false }
+    end
+
+    context 'when simpleonoff_state is "1"' do
+      let(:state) { '1' }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#toggle!' do
+    before { stub_request(:get, api_cmd_url).to_return(status: 200) }
+
+    let(:api_cmd_url) do
+      "https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=setsimpleonoff&#{lightbulb.ain}&onoff=#{onoff}"
+    end
+
+    context 'when the lightbulb is off' do
+      let(:state) { "0" }
+      let(:onoff) { "1" }
+
+      it "switches the lightbulb on" do
+        expect { lightbulb.toggle! }
+          .to change { lightbulb.active? }
+          .from(false).to(true)
+
+        expect(a_request(:get, api_cmd_url)).to have_been_made.once
+      end
+    end
+
+    context 'when the lightbulb is on' do
+      let(:state) { "1" }
+      let(:onoff) { "0" }
+
+      it "switches the lightbulb off" do
+        expect { lightbulb.toggle! }
+          .to change { lightbulb.active? }
+          .from(true).to(false)
+
+        expect(a_request(:get, api_cmd_url)).to have_been_made.once
+      end
+    end
+  end
+end

--- a/spec/fritzbox/smarthome/null_logger_spec.rb
+++ b/spec/fritzbox/smarthome/null_logger_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Fritzbox::Smarthome::NullLogger do
+
+  shared_examples_for 'a Ruby `Logger`-compatible interface' do |meth|
+    describe "##{meth}" do
+      it "will not output anything" do
+        expect { described_class.new.public_send(meth) }
+          .to_not output.to_stdout
+        expect { described_class.new.public_send(meth) }
+          .to_not output.to_stderr
+      end
+    end
+  end
+
+  it_behaves_like 'a Ruby `Logger`-compatible interface', :info
+  it_behaves_like 'a Ruby `Logger`-compatible interface', :warn
+  it_behaves_like 'a Ruby `Logger`-compatible interface', :error
+  it_behaves_like 'a Ruby `Logger`-compatible interface', :fatal
+  it_behaves_like 'a Ruby `Logger`-compatible interface', :debug
+end

--- a/spec/support/fixtures/getdevicelistinfos.xml
+++ b/spec/support/fixtures/getdevicelistinfos.xml
@@ -66,7 +66,7 @@
       <state>0</state>
     </alert>
   </device>
-    <device identifier="12345 678905" id="13" functionbitmask="320" fwversion="03.54" productname="FRITZ!DECT 200">
+  <device identifier="12345 678905" id="13" functionbitmask="320" fwversion="03.54" productname="FRITZ!DECT 200">
     <present>1</present>
     <name>FRITZ!DECT 200 Steckdose</name>
     <manufacturer>AVM</manufacturer>
@@ -90,4 +90,13 @@
     </temperature>
   </device>
   <device identifier="12345 54321" id="4711" functionbitmask="007" fwversion="0815" productname="Sub-Etha Radio Transmitter"></device>
+  <device identifier="11111 2233445" id="406" functionbitmask="1" fwversion="34.10.16.16.015" manufacturer="AVM" productname="FRITZ!DECT 500">
+    <present>
+      1
+    </present>
+    <txbusy>
+      0
+    </txbusy>
+    <name>Flurlampe</name>
+  </device>
 </devicelist>


### PR DESCRIPTION
So far, only switching them on and off support

Future refactoring could extract the `#toggle!` and `#active?` into a mixin like `OnOffSwitchable` (terrible name, but you get the idea :wink: ) to provide a uniform interface for all things on-off'able.