### PR TITLE
Unify on off interface

### DIFF
--- a/lib/fritzbox/smarthome.rb
+++ b/lib/fritzbox/smarthome.rb
@@ -5,6 +5,7 @@ require 'nori'
 
 require 'fritzbox/smarthome/version'
 require 'fritzbox/smarthome/null_logger'
+require 'fritzbox/smarthome/properties'
 require 'fritzbox/smarthome/resource'
 require 'fritzbox/smarthome/actor'
 require 'fritzbox/smarthome/heater'

--- a/lib/fritzbox/smarthome/lightbulb.rb
+++ b/lib/fritzbox/smarthome/lightbulb.rb
@@ -4,32 +4,12 @@ module Fritzbox
   module Smarthome
     class Lightbulb < Actor
 
-      attr_accessor \
-        :simpleonoff_state
+      include Properties::SimpleOnOff
 
       class << self
         def match?(data)
           data.fetch('@productname', '') =~ /FRITZ!DECT 5\d{2}/i
         end
-
-        def new_from_api(data)
-          instance = super
-          instance.assign_attributes(
-            simpleonoff_state:   data.dig('simpleonoff', 'state').to_i,
-          )
-          instance
-        end
-      end
-
-      def active?
-        simpleonoff_state == 1
-      end
-
-      def toggle!
-        value = active? ? 0 : 1
-        response = self.class.get(command: 'setsimpleonoff', ain: ain, onoff: value)
-
-        response.ok? && @simpleonoff_state = value
       end
     end
   end

--- a/lib/fritzbox/smarthome/properties.rb
+++ b/lib/fritzbox/smarthome/properties.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'fritzbox/smarthome/properties/simple_on_off'
+
+module Fritzbox
+  module Smarthome
+    module Properties
+    end
+  end
+end

--- a/lib/fritzbox/smarthome/properties/simple_on_off.rb
+++ b/lib/fritzbox/smarthome/properties/simple_on_off.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Fritzbox
+  module Smarthome
+    module Properties
+      # Defines a common interface/behaviour for actors with the "simpleonoff" state.
+      # The including class is expected to have an `ain` attribute defined.
+      module SimpleOnOff
+        extend ActiveSupport::Concern
+
+        included do
+          attr_accessor :simpleonoff_state
+        end
+
+        module ClassMethods
+          def new_from_api(data)
+            instance = defined?(super) ? super : new
+            instance.simpleonoff_state = data.dig('simpleonoff', 'state').to_i
+            instance
+          end
+        end
+
+        # @return [Boolean]
+        def active?
+          simpleonoff_state.to_s == "1"
+        end
+
+        # Makes a request to the Fritzbox and set the current instance's active state.
+        #
+        # The instance state is kept in memory and not checked with the Fritzbox state. It is
+        # possible that the device is switched on/off through other means.
+        #
+        # @example
+        #     lightbulb.active?
+        #     # => true
+        #     lightbulb.toggle!
+        #     # => 0
+        #     lightbulb.active?
+        #     # => false
+        # @return [false, Integer] Returns the new on/off state or false when the request
+        #     was unsuccessful
+        # @raise [ArgumentError] if the including class does not respond to `#ain`
+        def toggle!
+          raise ArgumentError, "Attribute `ain` is missing on #{inspect}" unless respond_to?(:ain)
+          value = active? ? 0 : 1
+          response =
+            Fritzbox::Smarthome::Resource.get(command: 'setsimpleonoff', ain: ain, onoff: value)
+
+          response.ok? && @simpleonoff_state = value
+        end
+      end
+    end
+  end
+end

--- a/lib/fritzbox/smarthome/switch.rb
+++ b/lib/fritzbox/smarthome/switch.rb
@@ -2,12 +2,13 @@ module Fritzbox
   module Smarthome
     class Switch < Actor
 
+      include Properties::SimpleOnOff
+
       attr_accessor \
         :switch_state,
         :switch_mode,
         :switch_lock,
         :switch_devicelock,
-        :simpleonoff_state,
         :powermeter_voltage,
         :powermeter_power,
         :powermeter_energy,
@@ -26,7 +27,6 @@ module Fritzbox
             switch_mode:         data.dig('switch', 'mode').to_s,
             switch_lock:         data.dig('switch', 'lock').to_i,
             switch_devicelock:   data.dig('switch', 'devicelock').to_i,
-            simpleonoff_state:   data.dig('simpleonoff', 'state').to_i,
             powermeter_voltage:  data.dig('powermeter', 'voltage').to_i,
             powermeter_power:    data.dig('powermeter', 'power').to_i,
             powermeter_energy:   data.dig('powermeter', 'energy').to_i,

--- a/spec/fritzbox/smarthome/lightbulb_spec.rb
+++ b/spec/fritzbox/smarthome/lightbulb_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Fritzbox::Smarthome::Lightbulb do
       to_return(body: '<SessionInfo><SID>ff88e4d39354992f</SID></SessionInfo>')
   end
 
+  it_behaves_like "a device with a simple on/off interface"
+
   describe '.all' do
     it 'returns a list of lightbulbs' do
       stub_request(:get, 'https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=getdevicelistinfos').
@@ -27,54 +29,6 @@ RSpec.describe Fritzbox::Smarthome::Lightbulb do
       expect(lightbulb.ain).to                    eq '11111 2233445'
       expect(lightbulb.name).to                   eq 'Flurlampe'
       expect(lightbulb.manufacturer).to           eq 'AVM'
-    end
-  end
-
-  describe '#active?' do
-    subject { lightbulb.active? }
-
-    context 'when simpleonoff_state is "0"' do
-      let(:state) { '0' }
-      it { is_expected.to be false }
-    end
-
-    context 'when simpleonoff_state is "1"' do
-      let(:state) { '1' }
-      it { is_expected.to be true }
-    end
-  end
-
-  describe '#toggle!' do
-    before { stub_request(:get, api_cmd_url).to_return(status: 200) }
-
-    let(:api_cmd_url) do
-      "https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=setsimpleonoff&#{lightbulb.ain}&onoff=#{onoff}"
-    end
-
-    context 'when the lightbulb is off' do
-      let(:state) { "0" }
-      let(:onoff) { "1" }
-
-      it "switches the lightbulb on" do
-        expect { lightbulb.toggle! }
-          .to change { lightbulb.active? }
-          .from(false).to(true)
-
-        expect(a_request(:get, api_cmd_url)).to have_been_made.once
-      end
-    end
-
-    context 'when the lightbulb is on' do
-      let(:state) { "1" }
-      let(:onoff) { "0" }
-
-      it "switches the lightbulb off" do
-        expect { lightbulb.toggle! }
-          .to change { lightbulb.active? }
-          .from(true).to(false)
-
-        expect(a_request(:get, api_cmd_url)).to have_been_made.once
-      end
     end
   end
 end

--- a/spec/fritzbox/smarthome/properties/simple_on_off_spec.rb
+++ b/spec/fritzbox/smarthome/properties/simple_on_off_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+RSpec.describe Fritzbox::Smarthome::Properties::SimpleOnOff do
+  subject(:instance) { generic_class.new }
+
+  let(:generic_class) do
+    Class.new {
+      def ain
+        @ain ||= ("A".."Z").to_a.shuffle.sample(6).join
+      end
+    }.include described_class
+  end
+
+  it "adds a `new_from_api` class method if it doesn't exist" do
+    expect(generic_class).to respond_to(:new_from_api).with(1).argument
+  end
+
+  it "adds a `simpleonoff_state` accessor" do
+    expect(instance).to respond_to(:simpleonoff_state).with(0).arguments
+    expect(instance).to respond_to(:simpleonoff_state=).with(1).arguments
+  end
+
+  it "adds an `active?` predicate method" do
+    expect(instance).to respond_to(:active?).with(0).arguments
+
+    expect { instance.simpleonoff_state = "1" }
+      .to change { instance.active? }
+      .to true
+
+    expect { instance.simpleonoff_state = :anything_else }
+      .to change { instance.active? }
+      .to false
+  end
+
+  describe "#toggle!" do
+    let(:response) { double("HTTP Response") }
+
+    before do
+      allow(Fritzbox::Smarthome::Resource).to receive(:get).and_return(response)
+    end
+
+    context "when the receiver doesn't respond to `#ain`" do
+      before do
+        instance.singleton_class.undef_method :ain
+      end
+
+      it "raises an ArgumentError" do
+        expect { instance.toggle! }
+          .to raise_error(ArgumentError, /Attribute `ain` is missing on/)
+      end
+    end
+
+    context "when the device is currently OFF" do
+      subject(:toggle!) { instance_on.toggle! }
+
+      let(:instance_off) { instance.tap { |o| o.simpleonoff_state = "0" } }
+
+      context "when the GET request is successful" do
+        before do
+          allow(response).to receive(:ok?).and_return(true)
+        end
+
+        it "changes the active state" do
+          retval = nil
+
+          expect { retval = instance_off.toggle! }
+            .to change { instance_off.active? }
+            .from(false)
+            .to(true)
+
+          expect(Fritzbox::Smarthome::Resource).to have_received(:get)
+            .with(command: 'setsimpleonoff', ain: String, onoff: 1)
+
+          expect(retval).to be 1
+        end
+      end
+
+      context "when the GET request is unsuccessful" do
+        before do
+          allow(response).to receive(:ok?).and_return(false)
+        end
+
+        it "leaves the active state untouched" do
+          retval = nil
+
+          expect { retval = instance_off.toggle! }
+            .not_to change { instance_off.active? }
+
+          expect(Fritzbox::Smarthome::Resource).to have_received(:get)
+            .with(command: 'setsimpleonoff', ain: String, onoff: 1)
+
+          expect(retval).to be false
+        end
+      end
+    end
+
+    context "when the device is currently ON" do
+      subject(:toggle!) { instance_on.toggle! }
+
+      let!(:instance_on) { instance.tap { |o| o.simpleonoff_state = "1" } }
+
+      context "when the GET request is successful" do
+        before do
+          allow(response).to receive(:ok?).and_return(true)
+        end
+
+        it "changes the active state" do
+          retval = nil
+
+          expect { retval = toggle! }
+            .to change { instance_on.active? }
+            .from(true)
+            .to(false)
+
+          expect(Fritzbox::Smarthome::Resource).to have_received(:get)
+            .with(command: 'setsimpleonoff', ain: String, onoff: 0)
+
+          expect(retval).to be 0
+        end
+      end
+
+      context "when the GET request is unsuccessful" do
+        before do
+          allow(response).to receive(:ok?).and_return(false)
+        end
+
+        it "leaves the active state untouched" do
+          retval = nil
+
+          expect { retval = toggle! }
+            .not_to change { instance_on.active? }
+
+          expect(Fritzbox::Smarthome::Resource).to have_received(:get)
+            .with(command: 'setsimpleonoff', ain: String, onoff: 0)
+
+          expect(retval).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/fritzbox/smarthome/switch_spec.rb
+++ b/spec/fritzbox/smarthome/switch_spec.rb
@@ -36,4 +36,12 @@ RSpec.describe Fritzbox::Smarthome::Switch do
       expect(smoke_detector.group_members).to          be nil
     end
   end
+
+  describe '#active?' do
+    it { is_expected.to respond_to :active? }
+  end
+
+  describe '#toggle!' do
+    it { is_expected.to respond_to :toggle! }
+  end
 end

--- a/spec/fritzbox/smarthome/switch_spec.rb
+++ b/spec/fritzbox/smarthome/switch_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Fritzbox::Smarthome::Switch do
       to_return(body: '<SessionInfo><SID>ff88e4d39354992f</SID></SessionInfo>')
   end
 
+  it_behaves_like "a device with a simple on/off interface"
+
   describe '.all' do
     it 'returns a list of switches' do
       stub_request(:get, 'https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=getdevicelistinfos').
@@ -35,13 +37,5 @@ RSpec.describe Fritzbox::Smarthome::Switch do
       expect(smoke_detector.temperature_offset).to     eq -5
       expect(smoke_detector.group_members).to          be nil
     end
-  end
-
-  describe '#active?' do
-    it { is_expected.to respond_to :active? }
-  end
-
-  describe '#toggle!' do
-    it { is_expected.to respond_to :toggle! }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'fritzbox/smarthome'
 require 'byebug'
 require 'webmock/rspec'
 
+Dir[File.expand_path("../support/**/*.rb", __FILE__)].each {|f| require f}
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "a device with a simple on/off interface" do
+  subject(:device) do described_class.new
+    described_class.new_from_api({ 'simpleonoff' => { 'state' => state } })
+  end
+
+
+
+  describe '#active?' do
+    subject { device.active? }
+
+    context 'when simpleonoff_state is "0"' do
+      let(:state) { '0' }
+      it { is_expected.to be false }
+    end
+
+    context 'when simpleonoff_state is "1"' do
+      let(:state) { '1' }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#toggle!' do
+    before { stub_request(:get, api_cmd_url).to_return(status: 200) }
+
+    let(:api_cmd_url) do
+      "https://fritz.box/webservices/homeautoswitch.lua?sid=ff88e4d39354992f&switchcmd=setsimpleonoff&#{device.ain}&onoff=#{onoff}"
+    end
+
+    context 'when the device is off' do
+      let(:state) { "0" }
+      let(:onoff) { "1" }
+
+      it "switches the device on" do
+        expect { device.toggle! }
+          .to change { device.active? }
+          .from(false).to(true)
+
+        expect(a_request(:get, api_cmd_url)).to have_been_made.once
+      end
+    end
+
+    context 'when the device is on' do
+      let(:state) { "1" }
+      let(:onoff) { "0" }
+
+      it "switches the device off" do
+        expect { device.toggle! }
+          .to change { device.active? }
+          .from(true).to(false)
+
+        expect(a_request(:get, api_cmd_url)).to have_been_made.once
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds a common interface to devices with the `simpleonoff_state` property. 

It moves the `#active?` and `#toggle!` from `Lightbulb` (added in https://github.com/klausmeyer/fritzbox-smarthome/pull/31) to a module that is now also included by `Switch` 